### PR TITLE
workaround error 400 when calling GetUser (i.e, in example.js)

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,30 +148,11 @@ fbSleep.fetchActiveUsers = function(config) {
 
 fbSleep.getUsers = function(config) {
     validateConfig(config);
-
-    return fbSleep.getBuddyList(config)
-        .then(function(users) {
-            if (_.size(users) === 0) {
-                throw new Error('No users found');
-            }
-
-            return users;
-        })
-
-        // Fallback to other ways of retriving users
-        .catch(function(e) {
-            console.error('Error getting buddyList. Will fallback to other means of retrieving friends', e);
-            var activeUsersRequest = fbSleep.fetchActiveUsers(config);
-            var lastActiveTimesRequest = fbSleep.getLastActiveTimes(config);
-
-            return Bluebird.all([activeUsersRequest, lastActiveTimesRequest])
-               .spread(function(activeUsers, lastActiveTimes) {
-                   return _.merge(activeUsers, lastActiveTimes);
-               });
-        })
-        .catch(function(e) {
-            console.error(e.stack);
-            throw new Error('Could not retrieve Facebook users');
+    var activeUsersRequest = fbSleep.fetchActiveUsers(config);
+    var lastActiveTimesRequest = fbSleep.getLastActiveTimes(config);
+    return Bluebird.all([activeUsersRequest, lastActiveTimesRequest])
+        .spread(function(activeUsers, lastActiveTimes) {
+            return _.merge(activeUsers, lastActiveTimes);
         });
 };
 


### PR DESCRIPTION
The current way of getting active users doesn't work.  It returns error 400.
In order to mitigate this problem that affects both example.js and other repositories relying on fb-sleep, such as fb-sleep-stats, I removed the failing code and used the fall back the developer has left that works properly and returns the current active users.  It should let users work until the problem is solved in a better way.

This commit resolves issue:
[https://github.com/sqren/fb-sleep-stats/issues/83](url)
