### PR TITLE
Fix HTTP 400 response when clientid is not provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ function getLoadBalancerInfo(config) {
         url: 'https://5-edge-chat.facebook.com/pull',
         jar: getCookieJar(config, 'https://5-edge-chat.facebook.com'),
         qs: {
+            clientid: 0,
             channel: 'p_' + config.c_user,
             seq: 1,
             partition: -2,
@@ -82,6 +83,7 @@ fbSleep.getBuddyList = function(config) {
                 url: 'https://5-edge-chat.facebook.com/pull',
                 jar: getCookieJar(config, 'https://5-edge-chat.facebook.com'),
                 qs: {
+                    clientid: 0,
                     channel: 'p_' + config.c_user,
                     seq: 1,
                     partition: -2,


### PR DESCRIPTION
This fixes the 400 response because the clientid required for the "API" is not provided:
```
Error getting buddyList. Will fallback to other means of retrieving friends { StatusCodeError: 400 -
```